### PR TITLE
Add support for snapshots in plugin

### DIFF
--- a/semantic-versioning/src/functionalTest/kotlin/io/github/serpro69/semverkt/gradle/plugin/fixture/SemverKtTestProject.kt
+++ b/semantic-versioning/src/functionalTest/kotlin/io/github/serpro69/semverkt/gradle/plugin/fixture/SemverKtTestProject.kt
@@ -10,6 +10,7 @@ import kotlin.io.path.writeText
 class SemverKtTestProject(
     defaultSettings: Boolean = false,
     multiModule: Boolean = false,
+    useSnapshots: Boolean = false,
 ) : AbstractProject() {
 
     private val gradlePropertiesFile = projectDir.resolve("gradle.properties")
@@ -40,7 +41,7 @@ class SemverKtTestProject(
             ${if (multiModule) "include(\"submodule\")" else ""}
             """.trimIndent()
         )
-        else writePluginSettings(multiModule)
+        else writePluginSettings(multiModule = multiModule, useSnapshots = useSnapshots)
 
         // Apply our plugin
         buildFile.writeBuildFile()
@@ -58,7 +59,7 @@ class SemverKtTestProject(
         }
     }
 
-    fun writePluginSettings(multiModule: Boolean) {
+    fun writePluginSettings(multiModule: Boolean, useSnapshots: Boolean) {
         settingsFile.writeText(
             """
             import java.nio.file.Paths
@@ -75,6 +76,9 @@ class SemverKtTestProject(
                     repo {
                         directory = Paths.get("${projectDir.absolutePathString()}")
                     }
+                }
+                version {
+                    ${if (useSnapshots) "useSnapshots = true" else ""}
                 }
             }
 

--- a/semantic-versioning/src/main/kotlin/io/github/serpro69/semverkt/gradle/plugin/SemverKtPlugin.kt
+++ b/semantic-versioning/src/main/kotlin/io/github/serpro69/semverkt/gradle/plugin/SemverKtPlugin.kt
@@ -139,13 +139,10 @@ class SemverKtPlugin : Plugin<Settings> {
                     project.version = nextVersion
                     logger.log(LogLevel.DEBUG, "Set project.version: ${(project.version)}")
                 }
-                else -> {
-//                    if (config.useSnapshots) {
-//                        project.version = snapshot(increaseVersion)
-//                        logger.log(LogLevel.DEBUG, "Set project.version: ${(project.version)}")
-//                    }
-                    logger.log(LogLevel.DEBUG, "Not doing anything...")
-                }
+                else -> if (config.version.useSnapshots) {
+                    project.version = snapshot(increaseVersion)
+                    logger.log(LogLevel.DEBUG, "Set project.version: ${(project.version)}")
+                } else logger.log(LogLevel.DEBUG, "Not doing anything...")
             }
             logger.log(LogLevel.INFO, "Done...")
             Triple(null, latestVersion, nextVersion)

--- a/semantic-versioning/src/main/kotlin/io/github/serpro69/semverkt/gradle/plugin/SemverKtPluginConfig.kt
+++ b/semantic-versioning/src/main/kotlin/io/github/serpro69/semverkt/gradle/plugin/SemverKtPluginConfig.kt
@@ -40,6 +40,7 @@ class SemverKtPluginConfig(settings: Settings?) : Configuration {
             preReleaseId = config.version.preReleaseId
             initialPreRelease = config.version.initialPreRelease
             snapshotSuffix = config.version.snapshotSuffix
+            useSnapshots = false
         }
     }
 
@@ -67,6 +68,7 @@ class SemverKtPluginVersionConfig internal constructor() : VersionConfig {
     override var preReleaseId: String = super.preReleaseId
     override var initialPreRelease: Int = super.initialPreRelease
     override var snapshotSuffix: String = super.snapshotSuffix
+    var useSnapshots: Boolean = false
 }
 
 @ConfigDsl

--- a/semantic-versioning/src/main/kotlin/io/github/serpro69/semverkt/gradle/plugin/tasks/TagTask.kt
+++ b/semantic-versioning/src/main/kotlin/io/github/serpro69/semverkt/gradle/plugin/tasks/TagTask.kt
@@ -6,7 +6,6 @@ import io.github.serpro69.semverkt.spec.Semver
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.gradle.api.logging.LogLevel.DEBUG
-import org.gradle.api.logging.LogLevel.INFO
 import org.gradle.api.logging.LogLevel.LIFECYCLE
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
@@ -39,6 +38,9 @@ abstract class TagTask : SemverReleaseTask() {
         when {
             // current version points at HEAD - don't do anything
             current != null -> logger.log(LIFECYCLE, "Current version: $current")
+            next != null && next.toString().endsWith(config.get().version.snapshotSuffix) -> {
+                logger.log(LIFECYCLE, "Snapshot version, not doing anything")
+            }
             // release new version
             (next != null && latest != null) && (next > latest) -> {
                 logger.log(LIFECYCLE, "Calculated next version: $next")
@@ -57,8 +59,8 @@ abstract class TagTask : SemverReleaseTask() {
         if (!dryRun.get()) run {
             // check if tag exists, don't try to create a duplicate
             val tagExists = GitRepository(config).use { repo ->
-                repo.tags().any { 
-                    Semver(it.name.replace(Regex("""^refs/tags/${config.git.tag.prefix}"""), "")) == nextVer 
+                repo.tags().any {
+                    Semver(it.name.replace(Regex("""^refs/tags/${config.git.tag.prefix}"""), "")) == nextVer
                 }
             }
             if (!tagExists) {


### PR DESCRIPTION
This is still WIP

- [x] release version should **only** be set when either commit contains one of the keywords (e.g. `[major]`, `[minor]`, etc), or we set `release` gradle property (e.g. `-Prelease`)
- [x] if neither is done, and `useSnapshots` is `true` - next version should be a snapshot version with the increment either via `increment` gradle property (i.e. `-Pincrement`) or if not set use `defaultIncrement` otherwise
- [x] if `useSnapshots` is `false`, just using `-Pincrement` by itself shouldn't do anything
- [x] *NB! tags should never be created for snapshots*